### PR TITLE
Add watchify

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "es6-promise": "^3.0.2",
     "lodash": "^3.10.1",
     "whatwg-fetch": "^0.10.1"
+  },
+  "devDependencies": {
+    "watchify": "^3.6.1"
   }
 }


### PR DESCRIPTION
Adding watchify as dev dependency to resolve the following:

``````
➜  recipes-client git:(section-2-1) ✗ npm run dev

> recipes-client@1.0.0 dev /Users/jonathanstassen/Documents/Code/learn-lodash/recipes-client
> watchify app/main.js -d -o assets/js/app.js -v

sh: watchify: command not found

npm ERR! Darwin 14.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "run" "dev"
npm ERR! node v0.12.7
npm ERR! npm  v3.5.2
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! recipes-client@1.0.0 dev: `watchify app/main.js -d -o assets/js/app.js -v`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the recipes-client@1.0.0 dev script 'watchify app/main.js -d -o assets/js/app.js -v'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the recipes-client package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     watchify app/main.js -d -o assets/js/app.js -v
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs recipes-client
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls recipes-client
npm ERR! There is likely additional logging output above.```
``````
